### PR TITLE
feat: add service-account OAuth (client_id/client_secret) auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,17 @@ and deploy the new version to the users.
 
 If you're building the provider, follow the instructions to [install it as a plugin.](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin) After placing it into your plugins directory,  run `terraform init` to initialize it.
 
-The Jumpcloud API key needs to be set before using the provider. It can either be retrieved via the API or through the UI : When selecting a resource, the ID is part of URL.
-Export `JUMPCLOUD_API_KEY` to set it.
+### Authentication
 
-The Jumpcloud "Organization ID" is optional as only needed for multi-tenant-setups.
-Export `JUMPCLOUD_ORG_ID` to set it.
+The provider supports two mutually-exclusive auth modes (configure one):
+
+* **Service-account OAuth (recommended):** set `client_id` + `client_secret`
+  (or export `JUMPCLOUD_CLIENT_ID` / `JUMPCLOUD_CLIENT_SECRET`) from a JumpCloud
+  Service Account. The provider exchanges them for a short-lived Bearer access
+  token via the `client_credentials` grant. Not tied to an individual account.
+* **Legacy x-api-key:** set `api_key` (or export `JUMPCLOUD_API_KEY`), an
+  admin-user API key retrieved via the API or the UI. OAuth takes precedence
+  when both are set.
+
+The Jumpcloud "Organization ID" is optional and only needed for
+multi-tenant-setups. Export `JUMPCLOUD_ORG_ID` to set it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,31 @@
 This provider can be used to add users&groups to
 Jumpcloud as well as the mappings.
 
+## Authentication
+
+The provider supports two mutually-exclusive auth modes. Configure **one**:
+
+* **Service-account OAuth (recommended)** — `client_id` + `client_secret` from a
+  JumpCloud Service Account. The provider performs a `client_credentials` grant
+  against `https://admin-oauth.id.jumpcloud.com/oauth2/token` at configure time
+  and sends the resulting short-lived (~1h) token as `Authorization: Bearer`.
+  Not tied to a person.
+* **Legacy x-api-key** — `api_key`, an admin-user API key sent as `x-api-key`.
+
+OAuth takes precedence when both are set. `client_id` and `client_secret` must
+be provided together. Each can be supplied via environment variable
+(`JUMPCLOUD_CLIENT_ID`, `JUMPCLOUD_CLIENT_SECRET`, `JUMPCLOUD_API_KEY`).
+
+```hcl
+provider "jumpcloud" {
+  client_id     = var.jc_client_id
+  client_secret = var.jc_client_secret
+}
+```
+
+The minted token lives for the run (~1h) — sufficient for a single plan/apply.
+An apply that runs longer than the token lifetime is an accepted edge case.
+
 ## ToDo
  * Extended Documentation
  * System Groups

--- a/jumpcloud/config.go
+++ b/jumpcloud/config.go
@@ -1,26 +1,106 @@
 package jumpcloud
 
-import jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
-const (
-	headerAccept = "application/json"
+	jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
 )
+
+const headerAccept = "application/json"
+
+// tokenEndpoint is JumpCloud's OAuth2 token endpoint for service-account
+// client_credentials grants. Service accounts are OAuth-only: the minted
+// access token must be sent as `Authorization: Bearer`, NOT `x-api-key`
+// (JumpCloud returns 401 for an OAuth token presented in x-api-key).
+// It is a var rather than a const so tests can point it at a stub server.
+var tokenEndpoint = "https://admin-oauth.id.jumpcloud.com/oauth2/token"
 
 // Config holds the JC configuration
 type Config struct {
-	APIKey string // User specific auth token
-	OrgID  string // Organization ID
+	APIKey       string // Legacy x-api-key auth token (admin-user key)
+	ClientID     string // Service-account OAuth client id
+	ClientSecret string // Service-account OAuth client secret
+	OrgID        string // Organization ID
 }
 
 // Client instantiates a jcapiv2.Configuration struct that is passed
-// to every Resource operation
-func (c *Config) Client() interface{} {
+// to every Resource operation.
+//
+// Two auth modes are supported:
+//   - Service-account OAuth (client_id + client_secret): a client_credentials
+//     grant mints a short-lived (~1h) Bearer access token sent as
+//     `Authorization: Bearer <token>`. Preferred — not tied to a person.
+//   - Legacy x-api-key (api_key): an admin-user API key sent as `x-api-key`.
+//
+// OAuth takes precedence when both are configured.
+func (c *Config) Client() (interface{}, error) {
 	config := jcapiv2.NewConfiguration()
-	config.AddDefaultHeader("x-api-key", c.APIKey)
+
+	if c.ClientID != "" && c.ClientSecret != "" {
+		token, err := fetchAccessToken(c.ClientID, c.ClientSecret)
+		if err != nil {
+			return nil, err
+		}
+		config.AddDefaultHeader("Authorization", "Bearer "+token)
+	} else {
+		config.AddDefaultHeader("x-api-key", c.APIKey)
+	}
 
 	if c.OrgID != "" {
 		config.AddDefaultHeader("x-org-id", c.OrgID)
 	}
 	// Instantiate the API client
-	return config
+	return config, nil
+}
+
+// fetchAccessToken performs a client_credentials OAuth2 grant against
+// JumpCloud's service-account token endpoint and returns the access token.
+//
+// The token is minted once per provider configuration (~1h TTL) — enough for a
+// single plan/apply. An apply that runs longer than the token lifetime is an
+// accepted edge case (the provider would need to be re-configured / re-run).
+func fetchAccessToken(clientID, clientSecret string) (string, error) {
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("scope", "api")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("building JumpCloud token request: %w", err)
+	}
+	req.SetBasicAuth(clientID, clientSecret)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", headerAccept)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("requesting JumpCloud access token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return "", fmt.Errorf("JumpCloud token endpoint returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var payload struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decoding JumpCloud token response: %w", err)
+	}
+	if payload.AccessToken == "" {
+		return "", fmt.Errorf("JumpCloud token endpoint returned an empty access_token")
+	}
+	return payload.AccessToken, nil
 }

--- a/jumpcloud/config_test.go
+++ b/jumpcloud/config_test.go
@@ -1,0 +1,144 @@
+package jumpcloud
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
+)
+
+// withStubTokenEndpoint points tokenEndpoint at the given test server for the
+// duration of the test and restores it afterwards.
+func withStubTokenEndpoint(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	prev := tokenEndpoint
+	tokenEndpoint = srv.URL
+	t.Cleanup(func() { tokenEndpoint = prev })
+}
+
+func TestFetchAccessToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, secret, ok := r.BasicAuth()
+		if !ok || id != "the-id" || secret != "the-secret" {
+			t.Errorf("expected basic auth the-id/the-secret, got id=%q secret=%q ok=%v", id, secret, ok)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %s", err)
+		}
+		if got := r.Form.Get("grant_type"); got != "client_credentials" {
+			t.Errorf("grant_type = %q, want client_credentials", got)
+		}
+		if got := r.Form.Get("scope"); got != "api" {
+			t.Errorf("scope = %q, want api", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"abc123","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer srv.Close()
+	withStubTokenEndpoint(t, srv)
+
+	token, err := fetchAccessToken("the-id", "the-secret")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if token != "abc123" {
+		t.Fatalf("token = %q, want abc123", token)
+	}
+}
+
+func TestFetchAccessTokenNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+	}))
+	defer srv.Close()
+	withStubTokenEndpoint(t, srv)
+
+	if _, err := fetchAccessToken("x", "y"); err == nil {
+		t.Fatal("expected an error for a 401 response, got nil")
+	}
+}
+
+func TestFetchAccessTokenEmptyToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token_type":"Bearer"}`))
+	}))
+	defer srv.Close()
+	withStubTokenEndpoint(t, srv)
+
+	if _, err := fetchAccessToken("x", "y"); err == nil {
+		t.Fatal("expected an error for an empty access_token, got nil")
+	}
+}
+
+func TestClientOAuthSetsBearerHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"tok"}`))
+	}))
+	defer srv.Close()
+	withStubTokenEndpoint(t, srv)
+
+	c := &Config{ClientID: "id", ClientSecret: "secret", OrgID: "org"}
+	out, err := c.Client()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	cfg := out.(*jcapiv2.Configuration)
+	if got := cfg.DefaultHeader["Authorization"]; got != "Bearer tok" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer tok")
+	}
+	if _, ok := cfg.DefaultHeader["x-api-key"]; ok {
+		t.Error("x-api-key header should not be set in OAuth mode")
+	}
+	if got := cfg.DefaultHeader["x-org-id"]; got != "org" {
+		t.Errorf("x-org-id = %q, want org", got)
+	}
+}
+
+func TestClientAPIKeyFallback(t *testing.T) {
+	c := &Config{APIKey: "legacy-key"}
+	out, err := c.Client()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	cfg := out.(*jcapiv2.Configuration)
+	if got := cfg.DefaultHeader["x-api-key"]; got != "legacy-key" {
+		t.Errorf("x-api-key = %q, want legacy-key", got)
+	}
+	if _, ok := cfg.DefaultHeader["Authorization"]; ok {
+		t.Error("Authorization header should not be set in api_key mode")
+	}
+}
+
+func TestConvertV2toV1ConfigCarriesBearer(t *testing.T) {
+	v2 := jcapiv2.NewConfiguration()
+	v2.AddDefaultHeader("Authorization", "Bearer tok")
+	v2.AddDefaultHeader("x-org-id", "org")
+
+	v1 := convertV2toV1Config(v2)
+	if got := v1.DefaultHeader["Authorization"]; got != "Bearer tok" {
+		t.Errorf("v1 Authorization = %q, want %q", got, "Bearer tok")
+	}
+	if got := v1.DefaultHeader["x-org-id"]; got != "org" {
+		t.Errorf("v1 x-org-id = %q, want org", got)
+	}
+	if _, ok := v1.DefaultHeader["x-api-key"]; ok {
+		t.Error("v1 x-api-key should not be set when only Authorization is present")
+	}
+}
+
+func TestConvertV2toV1ConfigCarriesAPIKey(t *testing.T) {
+	v2 := jcapiv2.NewConfiguration()
+	v2.AddDefaultHeader("x-api-key", "legacy-key")
+
+	v1 := convertV2toV1Config(v2)
+	if got := v1.DefaultHeader["x-api-key"]; got != "legacy-key" {
+		t.Errorf("v1 x-api-key = %q, want legacy-key", got)
+	}
+	if _, ok := v1.DefaultHeader["Authorization"]; ok {
+		t.Error("v1 Authorization should not be set when only x-api-key is present")
+	}
+}

--- a/jumpcloud/provider.go
+++ b/jumpcloud/provider.go
@@ -15,9 +15,23 @@ func Provider() *schema.Provider {
 		Schema: map[string]*schema.Schema{
 			"api_key": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc("JUMPCLOUD_API_KEY", nil),
 				Description: descriptions["api_key"],
+			},
+			"client_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("JUMPCLOUD_CLIENT_ID", nil),
+				Description: descriptions["client_id"],
+			},
+			"client_secret": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				DefaultFunc: schema.EnvDefaultFunc("JUMPCLOUD_CLIENT_SECRET", nil),
+				Description: descriptions["client_secret"],
 			},
 			"org_id": {
 				Type:        schema.TypeString,
@@ -47,16 +61,38 @@ var descriptions map[string]string
 
 func init() {
 	descriptions = map[string]string{
-		"api_key": "The x-api-key header used to connect to JumpCloud.",
-		"org_id":  "The x-org-id header used to connect to JumpCloud.",
+		"api_key": "Legacy x-api-key used to connect to JumpCloud (admin-user API key). " +
+			"Mutually exclusive with client_id/client_secret; OAuth takes precedence when both are set.",
+		"client_id": "JumpCloud service-account OAuth client id. When set together with " +
+			"client_secret, the provider mints a short-lived Bearer access token via the " +
+			"client_credentials grant instead of using the legacy x-api-key.",
+		"client_secret": "JumpCloud service-account OAuth client secret (paired with client_id).",
+		"org_id":        "The x-org-id header used to connect to JumpCloud.",
 	}
 }
 
 func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	config := Config{
-		APIKey: d.Get("api_key").(string),
-		OrgID:  d.Get("org_id").(string),
+		APIKey:       d.Get("api_key").(string),
+		ClientID:     d.Get("client_id").(string),
+		ClientSecret: d.Get("client_secret").(string),
+		OrgID:        d.Get("org_id").(string),
 	}
 
-	return config.Client(), nil
+	// client_id and client_secret are only meaningful as a pair.
+	if (config.ClientID != "") != (config.ClientSecret != "") {
+		return nil, diag.Errorf("client_id and client_secret must be set together")
+	}
+
+	hasOAuth := config.ClientID != "" && config.ClientSecret != ""
+	if !hasOAuth && config.APIKey == "" {
+		return nil, diag.Errorf("no JumpCloud credentials configured: set either " +
+			"client_id + client_secret (service-account OAuth) or api_key (legacy x-api-key)")
+	}
+
+	client, err := config.Client()
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+	return client, nil
 }

--- a/jumpcloud/utils.go
+++ b/jumpcloud/utils.go
@@ -5,11 +5,17 @@ import (
 	jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
 )
 
-// We receive a v2config from the TF base code but need a v1config to continue. So, we take the only
-// preloaded element (the x-api-key) and populate the v1config with it.
+// We receive a v2config from the TF base code but need a v1config to continue. So, we carry over the
+// auth header it was configured with — either the legacy x-api-key or the service-account
+// `Authorization: Bearer` token — plus the optional x-org-id.
 func convertV2toV1Config(v2config *jcapiv2.Configuration) *jcapiv1.Configuration {
 	configv1 := jcapiv1.NewConfiguration()
-	configv1.AddDefaultHeader("x-api-key", v2config.DefaultHeader["x-api-key"])
+	if v := v2config.DefaultHeader["Authorization"]; v != "" {
+		configv1.AddDefaultHeader("Authorization", v)
+	}
+	if v := v2config.DefaultHeader["x-api-key"]; v != "" {
+		configv1.AddDefaultHeader("x-api-key", v)
+	}
 	if v2config.DefaultHeader["x-org-id"] != "" {
 		configv1.AddDefaultHeader("x-org-id", v2config.DefaultHeader["x-org-id"])
 	}


### PR DESCRIPTION
## Why

Migrating off dpinte's personal JumpCloud admin-user API key to a non-person `it-automation` **service account** (parent kata `cx3m`, hard deadline end of June 2026). JumpCloud service accounts are **OAuth-only**: their access tokens are rejected in `x-api-key` (401) and only work as `Authorization: Bearer` (verified live 2026-06-05). The provider previously hardcoded `x-api-key`, so it could not use the service account at all. This is the longest pole and **blocks the Atlantis cutover** (`nhdh`).

## What

Adds a second, preferred auth mode while keeping `x-api-key` for back-compat:

- **`provider.go`** — new `Optional` `client_id` / `client_secret` schema args (env `JUMPCLOUD_CLIENT_ID` / `JUMPCLOUD_CLIENT_SECRET`; `client_secret` + `api_key` now `Sensitive`). `api_key` relaxed `Required`→`Optional`. `providerConfigure` validates exactly one mode is configured and that id/secret are supplied as a pair.
- **`config.go`** — `Client()` mints a short-lived (~1h) Bearer token via the `client_credentials` grant against `admin-oauth.id.jumpcloud.com` when `client_id`/`secret` are set; otherwise falls back to `x-api-key`. OAuth wins when both are present. Token minted once per provider-configure — enough for a single plan/apply; a >1h apply is an accepted edge case.
- **`utils.go`** — `convertV2toV1Config` now carries the `Authorization` header (not just `x-api-key`), so the `jcapiv1` path (`resource_user`, `data_source_application`) authenticates under OAuth too. *(Easy to miss — without it the v1 resources would silently 401.)*

**No new dependencies** (stdlib `net/http`); `go mod tidy` is a no-op.

## Tests

`config_test.go` (unit, httptest stub): token exchange success / non-200 / empty-token; both `Client()` auth modes set the right header; v2→v1 header carry-over for both modes. Existing `TestProvider` (`InternalValidate`) still passes.

**Live end-to-end** (run before this PR, with the real `it-automation` creds from Vault `pass-it_devops-developer/jumpcloud-service-account`): `fetchAccessToken` minted a 1107-char token and authenticated a real `GET /api/v2/usergroups` → **200 OK**.

## Release / next steps

This PR is the code only. After merge, the **release is a privileged step for @dpinte**: tag (suggest **`v1.1.0`** — backward-compatible feature) and `goreleaser release --rm-dist` to `terraform.enthought.com`, then bump `JUMPCLOUD_VERSION` in `enthought/terraform`'s `deploy_providers.sh`. The Atlantis tfvars/vars.tf cutover is tracked separately in kata `nhdh`.

Optional pre-release re-verify against live:
```sh
export VAULT_ADDR=https://vault.enthought.com
creds=$(vault kv get -format=json pass-it_devops-developer/jumpcloud-service-account)
export JUMPCLOUD_CLIENT_ID=$(echo "$creds" | jq -r .data.data.client_id)
export JUMPCLOUD_CLIENT_SECRET=$(echo "$creds" | jq -r .data.data.client_secret)
# then run a no-op JumpCloud-touching `terraform plan` with the new provider build
```

Refs kata `g8hh` (parent `cx3m`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)