### PR TITLE
fix(ci): migrate .goreleaser.yml to v2 schema

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing
@@ -31,4 +32,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
The `release.yml` workflow pins `goreleaser-action` with `version: latest`, which now resolves to goreleaser **v2.x**. v2 requires an explicit `version: 2` and replaced `changelog.skip` with `changelog.disable`.

The v1.0.0 release predates v2 becoming `latest`, so the first tag push after it (`v1.1.0`) failed:
> only `version: 2` configuration files are supported, yours is `version: 0`

Two-line schema bump to unblock the release. No behavior change to the produced archives (default tar.gz naming, unchanged binary template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)